### PR TITLE
support aws_config::load_from_env and fix CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,13 +48,14 @@ jobs:
       - name: Setup minio
         run: |
           docker run \
+          --detach \
           --rm \
-          -p 9000:9000 \
-          -p 9001:9001 \
+          --publish 9000:9000 \
+          --publish 9001:9001 \
           --name minio \
-          -v "$(pwd)/parquet-testing:/data" \
-          -e "MINIO_ROOT_USER=AKIAIOSFODNN7EXAMPLE" \
-          -e "MINIO_ROOT_PASSWORD=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" \
+          --volume "$(pwd)/parquet-testing:/data" \
+          --env "MINIO_ROOT_USER=AKIAIOSFODNN7EXAMPLE" \
+          --env "MINIO_ROOT_PASSWORD=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" \
           quay.io/minio/minio server /data \
           --console-address ":9001"
       - name: Run tests
@@ -110,4 +111,3 @@ jobs:
         env:
           CARGO_HOME: "/github/home/.cargo"
           CARGO_TARGET_DIR: "/github/home/target"
-      

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,16 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0"
-aws-config = "0"
-aws-sdk-s3 = "0"
-aws-smithy-types = "0"
+async-trait = "0.1.52"
+aws-config = "0.5.2"
+aws-sdk-s3 = "0.5.2"
+aws-smithy-async = "0.35.2"
+aws-smithy-types = "0.35.2"
 aws-smithy-types-convert = { version = "0", features = ["convert-chrono"] }
-aws-types = "0"
-bytes = "1"
-datafusion = "6"
-futures = "0.3"
-http = "0"
-num_cpus = "1.13.0"
+aws-types = "0.5.2"
+bytes = "1.1.0"
+datafusion = "6.0.0"
+futures = "0.3.19"
+http = "0.2.6"
+num_cpus = "1.13.1"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs"] }

--- a/README.md
+++ b/README.md
@@ -9,20 +9,21 @@ Tests are run with [MinIO](https://min.io/) which provides a containerized imple
 First clone the test data repository:
 
 ```bash
-git clone https://github.com/apache/parquet-testing.git
+git submodule update --init --recursive
 ```
 
 Then start the MinIO container:
 
 ```bash
 docker run \
+--detach \
 --rm \
--p 9000:9000 \
--p 9001:9001 \
+--publish 9000:9000 \
+--publish 9001:9001 \
 --name minio \
--v "$(pwd)/parquet-testing:/data" \
--e "MINIO_ROOT_USER=AKIAIOSFODNN7EXAMPLE" \
--e "MINIO_ROOT_PASSWORD=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" \
+--volume "$(pwd)/parquet-testing:/data" \
+--env "MINIO_ROOT_USER=AKIAIOSFODNN7EXAMPLE" \
+--env "MINIO_ROOT_PASSWORD=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" \
 quay.io/minio/minio server /data \
 --console-address ":9001"
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,5 +14,4 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
-pub mod aws;
+pub mod object_store;

--- a/src/object_store/aws.rs
+++ b/src/object_store/aws.rs
@@ -364,7 +364,7 @@ mod tests {
         if let Some(file) = files.next().await {
             let sized_file = file.unwrap().sized_file;
             let mut reader = amazon_s3_file_system
-                .file_reader(sized_file.clone())
+                .file_reader(sized_file)
                 .unwrap()
                 .sync_chunk_reader(start as u64, length)
                 .unwrap();


### PR DESCRIPTION
- addresses https://github.com/datafusion-contrib/datafusion-objectstore-s3/issues/5 (and replaces https://github.com/datafusion-contrib/datafusion-objectstore-s3/pull/14)
- fixes CI tests
- update README