### PR TITLE
Update AWS SDK dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = "0.1.52"
-aws-config = "0.9.0"
-aws-sdk-s3 = "0.9.0"
-aws-smithy-async = "0.39.0"
-aws-smithy-types = "0.39.0"
-aws-smithy-types-convert = { version = "0.39.0", features = ["convert-chrono"] }
-aws-types = "0.9.0"
+aws-config = "0.47.0"
+aws-sdk-s3 = "0.17.0"
+aws-smithy-async = "0.47.0"
+aws-smithy-types = "0.47.0"
+aws-smithy-types-convert = { version = "0.47.0", features = ["convert-chrono"] }
+aws-types = "0.47.0"
 bytes = "1.1.0"
 datafusion-data-access = { version = "8.0.0" }
 futures = "0.3.19"

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use std::fmt::{Display, Formatter};
 
 /// Enum with all errors in this crate.
 /// PartialEq is to enable testing for specific error types
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum S3Error {
     /// Returned when functionaly is not yet available.
     NotImplemented(String),


### PR DESCRIPTION
Uses latest version of AWS SDK crates

P.S: tests fail, [observed elsewhere](https://github.com/datafusion-contrib/datafusion-objectstore-s3/pull/64#issuecomment-1156000215) as well